### PR TITLE
fix / connect method (no uppercase)

### DIFF
--- a/utils/message_brokers.py
+++ b/utils/message_brokers.py
@@ -140,7 +140,7 @@ class RabbitMQ(MessageBroker):
         # Check if connection to RabbitMQ is open, if not, reconnect
         if not self.connection.is_open:
             print("Connection to RabbitMQ is not open")
-            self.Connect()
+            self.connect()
 
         # Check if readChannel is closed, if yes, reinitialize
         if self.readChannel.is_closed:
@@ -177,7 +177,7 @@ class RabbitMQ(MessageBroker):
         # Handle connection and channel closure exceptions
         except pika.exceptions.ConnectionClosed:
             print('Reconnecting to queue')
-            self.Connect()
+            self.connect()
             self.publishChannel.basic_publish(
                 exchange=self.exchange, routing_key=self.target_queue_name, body=message)
         except pika.exceptions.ChannelClosed:


### PR DESCRIPTION
## Description

### Pull Request Title: fix / connect method (no uppercase)

### Description:
#### Motivation:
The current implementation contains method calls to `Connect` with an uppercase 'C', which does not follow Python's naming conventions for methods. Python's PEP 8 style guide recommends using lowercase for method names. This discrepancy can lead to confusion and potential errors in the codebase.

#### Changes:
- Renamed all instances of `Connect()` to `connect()` to adhere to Python's naming conventions.
- This change was applied across multiple occurrences within the `utils/message_brokers.py` file.

### Why This Improves the Project:
1. **Code Consistency**: Aligns with PEP 8, making the codebase more consistent and easier to read.
2. **Error Reduction**: Reduces the potential for errors due to incorrect method naming.
3. **Maintainability**: Enhances the maintainability of the code by adhering to widely accepted coding standards.

By ensuring that method names follow the correct convention, we improve the overall quality and readability of the code, making it easier for current and future contributors to understand and work with the codebase.