### PR TITLE
if frame_skip_factor == 0: skip

### DIFF
--- a/object_classification_yolov8.py
+++ b/object_classification_yolov8.py
@@ -130,6 +130,8 @@ while True:
     # frame_skip_factor is the factor by which the input video frames are skipped.
     frame_number, predicted_frames = 0, 0
     frame_skip_factor = int(cap.get(cv2.CAP_PROP_FPS) / var.CLASSIFICATION_FPS)
+    if frame_skip_factor == 0:
+        continue
 
     # Loop over the video frames, and perform object classification.
     # The classification process is done until the counter reaches the MAX_NUMBER_OF_PREDICTIONS or the last frame is reached.


### PR DESCRIPTION
## Description

### Pull Request Description

**Title:** if frame_skip_factor == 0: skip

**Motivation:**
The current implementation does not handle the scenario where the `frame_skip_factor` is calculated to be zero. This can occur when the frames per second (FPS) of the input video is less than or equal to the classification FPS defined in the `var.CLASSIFICATION_FPS` variable. In such cases, the current logic may lead to an infinite loop or unnecessary processing, which could degrade performance and lead to unexpected behavior.

**Changes:**
- Added a check to skip processing if `frame_skip_factor` is calculated to be zero.

**Why it improves the project:**
1. **Prevents Infinite Loops:** By skipping the frame processing when `frame_skip_factor` is zero, we avoid potential infinite loops that could halt the execution.
2. **Optimizes Performance:** Skipping unnecessary processing helps in optimizing the performance, especially when dealing with videos with low FPS.
3. **Improves Robustness:** This change makes the code more robust by handling edge cases, ensuring that the application behaves predictably under all conditions.
4. **Enhances Readability:** The added condition makes the intent of the code clearer, improving its maintainability.

This change ensures that the object classification process only proceeds when it is meaningful to do so, thereby enhancing the overall quality and reliability of the project.