### PR TITLE
fix/pods-restarting-on-vault-issue

### DIFF
--- a/utils/kerberos_vault.py
+++ b/utils/kerberos_vault.py
@@ -1,4 +1,5 @@
 import requests
+import requests.exceptions
 import json
 
 
@@ -87,8 +88,12 @@ class KerberosVault:
         headers = self.create_headers(
             message['payload']['key'], message['source'])
 
-        resp = requests.get(self.storage_uri +
-                            "/storage", headers=headers, timeout=10)
+        try:
+            resp = requests.get(self.storage_uri +
+                                "/storage", headers=headers, timeout=10)
+        except requests.exceptions.RequestException as e:
+            print("Error: failed to connect to Kerberos Vault:", e)
+            return str(e).encode()
 
         if resp is None or resp.status_code != 200:
             return resp.content


### PR DESCRIPTION
## Description

**Motivation & Impact**

Pods were restarting whenever Kerberos Vault was unavailable or slow to respond because connection-related exceptions from `requests.get()` were not handled. These unhandled exceptions caused the application to crash instead of failing gracefully.

This change adds explicit handling for `requests` connection errors when retrieving media from Kerberos Vault. By catching and handling these exceptions, the service can return a controlled error response instead of crashing.

As a result, the application becomes more resilient to temporary Vault outages or network issues, preventing unnecessary pod restarts and improving overall system stability.